### PR TITLE
fix: package.json typing path is wrong

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A quill plugin to deal with pasting and droping images and html including images",
   "main": "dist/index.umd.js",
   "module": "dist/index.es5.js",
-  "typings": "dist/types/index.d.ts",
+  "typings": "dist/types/src/index.d.ts",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
编译后dist目录结构如下
```
dist
├── index.es5.js
├── index.es5.js.map
├── index.umd.js
├── index.umd.js.map
├── lib
│   ├── src
│   │   ├── blots
│   │   │   ├── image.js
│   │   │   └── image.js.map
│   │   ├── index.js
│   │   ├── index.js.map
│   │   ├── interfaces.js
│   │   ├── interfaces.js.map
│   │   └── utils
│   │       ├── index.js
│   │       └── index.js.map
│   └── test
│       ├── index.test.js
│       └── index.test.js.map
└── types
    ├── src
    │   ├── blots
    │   │   └── image.d.ts
    │   ├── index.d.ts
    │   ├── interfaces.d.ts
    │   └── utils
    │       └── index.d.ts
    └── test
        └── index.test.d.ts
```

index.d.ts所在位置是`dist/types/src/index.d.ts`，
故此提交修改typings的路径为`dist/types/src/index.d.ts`。